### PR TITLE
Rename IaC Template Pipeline Default Branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         }
         stage('Build Environment') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 sh label: 'Run Terraform apply', script: 'make environment'
@@ -43,7 +43,7 @@ pipeline {
         }
         stage('Integration Tests') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 sleep(time:30, unit:"SECONDS") // Wait 30 seconds for DDNS daemon set to register new address, if applicable.
@@ -52,7 +52,7 @@ pipeline {
         }
         stage('Tag Module Release') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'GitHub_Jenkins-GCP', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
@@ -81,7 +81,7 @@ pipeline {
                      description: 'All tests passed',
                      targetUrl: "${env.BUILD_URL}/display/redirect")
 
-                    // Attempt to auto-merge this PR into master unless the 'no-merge' label exists to indicate otherwise.
+                    // Attempt to auto-merge this PR into main unless the 'no-merge' label exists to indicate otherwise.
                     if (! pullRequest.labels.contains("no-merge")) {
                         echo "No-merge label absent; attempting auto-merge."
 

--- a/modules/k8s-apps/main.tf
+++ b/modules/k8s-apps/main.tf
@@ -10,7 +10,7 @@ module "k8s-config" {
 }
 
 module "service-aphorismophilia" {
-  source                            = "github.com/mikeroach/aphorismophilia-terraform?ref=v17"
+  source                            = "github.com/mikeroach/aphorismophilia-terraform?ref=v2"
   dns_domain                        = var.dns_domain
   dns_hostname                      = var.gcp_project_shortname
   dockerhub_credentials             = var.dockerhub_credentials

--- a/modules/k8s-infra/outputs.tf
+++ b/modules/k8s-infra/outputs.tf
@@ -15,6 +15,6 @@ output "k8s_cluster_ca_certificate" {
 }
 
 output "k8s_endpoint" {
-  description = "IP address of Kubernetes cluster master"
+  description = "IP address of Kubernetes cluster API server endpoint"
   value       = google_container_cluster.k8s_cluster.endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,6 @@ output "k8s_cluster_ca_certificate" {
 */
 
 output "k8s_endpoint" {
-  description = "IP address of Kubernetes cluster master"
+  description = "IP address of Kubernetes cluster API server endpoint"
   value       = module.k8s-infra.k8s_endpoint
 }


### PR DESCRIPTION
This PR updates the repository's default branch to `main` in code and documentation to embrace recommended inclusive terminology per [IETF Internet-Draft draft-knodel-terminology-12](https://datatracker.ietf.org/doc/draft-knodel-terminology/).